### PR TITLE
Move deploy to Cloudflare Pages (drop Netlify config)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,0 @@
-[build]
-  # Static site — no build step. Publish the repository root as-is.
-  publish = "."
-  command = ""


### PR DESCRIPTION
Removendo o `netlify.toml` já que o deploy vai pro **Cloudflare Pages**.

O site é HTML estático na raiz, então no Cloudflare Pages basta:
- **Build command:** _(vazio)_
- **Build output directory:** `/`

Nenhum arquivo de config é necessário no repo.