### PR TITLE
Remove GitLab link and icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,31 +63,6 @@
           </svg>
         </a>
         <a
-          aria-label="Click to see all my open source projects on Gitlab"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://gitlab.com/delete21"
-          class="social-icons__icon"
-        >
-          <svg
-            class="svg-inline__fa svg-inline__fa--bigger"
-            style="margin-left: -6px"
-            aria-hidden="true"
-            role="img"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 496 512"
-          >
-            <path style="fill: #fc6d26" d="M461.17 301.83l-18.91-58.12-37.42-115.28a6.47 6.47 0 00-12.27 0l-37.42 115.21H230.82L193.4 128.43a6.46 6.46 0 00-12.26 0l-37.36 115.21-18.91 58.19a12.88 12.88 0 004.66 14.39L293 435l163.44-118.78a12.9 12.9 0 004.73-14.39" />
-            <path style="fill: #e24329" d="M293 434.91l62.16-191.28H230.87L293 434.91z" />
-            <path style="fill: #fc6d26" d="M293 434.91l-62.18-191.28h-87L293 434.91z" />
-            <path style="fill: #fca326" d="M143.75 243.69l-18.91 58.12a12.88 12.88 0 004.66 14.39L293 435 143.75 243.69z" />
-            <path style="fill: #e24329" d="M143.78 243.69h87.11l-37.49-115.2a6.47 6.47 0 00-12.27 0l-37.35 115.2z" />
-            <path style="fill: #fc6d26" d="M293 434.91l62.16-191.28h87.14L293 434.91z" />
-            <path style="fill: #fca326" d="M442.24 243.69l18.91 58.12a12.85 12.85 0 01-4.66 14.39L293 434.91l149.2-191.22z" />
-            <path style="fill: #e24329" d="M442.28 243.69h-87.1l37.42-115.2a6.46 6.46 0 0112.26 0l37.42 115.2z" />
-          </svg>
-        </a>
-        <a
           aria-label="Get in touch at Linkedin"
           target="_blank"
           rel="noopener noreferrer"


### PR DESCRIPTION
Remove o link e o ícone do GitLab da seção de redes sociais. Sobram GitHub e LinkedIn.